### PR TITLE
Remove clipped() modifier

### DIFF
--- a/Sources/FluidGradient/FluidGradient.swift
+++ b/Sources/FluidGradient/FluidGradient.swift
@@ -32,7 +32,6 @@ public struct FluidGradient: View {
                       blurValue: $blurValue)
         .blur(radius: pow(blurValue, blur))
         .accessibility(hidden: true)
-        .clipped()
     }
 }
 


### PR DESCRIPTION
Intead of always clipping the FluidGradient view - let the front end user decide whether or not clip it. 

With this change, it allows a user create a smaller blob, that can stretch beyond it's frame. 